### PR TITLE
Fix sender address for fault emails

### DIFF
--- a/src/app/api/send-fault-email/route.ts
+++ b/src/app/api/send-fault-email/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request) {
     }
 
     const { data, error } = await resend.emails.send({
-      from: `onboarding@resend.dev`,
+      from: fromEmail,
       to: [toEmail],
       subject: `🚨 Fault Alert: ${fault.description} on ${machineName}`,
       html: createFaultEmailTemplate(machineName, fault),


### PR DESCRIPTION
## Summary
- respect configured email address when sending fault notifications

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b1ab38bd48322ad48bb107d20f3d7